### PR TITLE
fix: adiciona módulos à _dashboard_

### DIFF
--- a/admin/controller/common/dashboard.php
+++ b/admin/controller/common/dashboard.php
@@ -76,6 +76,8 @@ class ControllerCommonDashboard extends Controller {
 			}
 		}
 
+		$data['rows'][] = $column;
+
 		if (DIR_STORAGE == DIR_SYSTEM . 'storage/') {
 			$data['security'] = $this->load->controller('common/security');
 		} else {


### PR DESCRIPTION
A depender da configuração da largura dos módulos,
alguns ficavam fora da _view_.

**01 - Extensões Dashboard**
![01 - Extensions](https://user-images.githubusercontent.com/606481/88983543-b830e080-d2a1-11ea-8e54-c9fd27637c03.png)

**02 - Antes**
![02 - Before](https://user-images.githubusercontent.com/606481/88983547-b8c97700-d2a1-11ea-9cfd-006ef0ea1bef.png)

**03 - Depois**
![03 - After](https://user-images.githubusercontent.com/606481/88983548-b9620d80-d2a1-11ea-8c68-a0cc76035c5c.png)


