### PR TITLE
fix: correção quebra na árvore de elementos HTML

### DIFF
--- a/catalog/view/javascript/common.js
+++ b/catalog/view/javascript/common.js
@@ -161,7 +161,7 @@ var cart = {
 
 					// Need to set timeout otherwise it wont update the total
 					setTimeout(function () {
-						$('#cart > button').html('<span id="cart-total"><i class="fa fa-shopping-cart"></i> ' + json['total'] + '</span>');
+						$('#cart > button').html('<i class="fa fa-shopping-cart"></i><span id="cart-total"> ' + json['total'] + '</span>');
 					}, 100);
 
 					$('html, body').animate({ scrollTop: 0 }, 'slow');
@@ -189,7 +189,7 @@ var cart = {
 			success: function(json) {
 				// Need to set timeout otherwise it wont update the total
 				setTimeout(function () {
-					$('#cart > button').html('<span id="cart-total"><i class="fa fa-shopping-cart"></i> ' + json['total'] + '</span>');
+					$('#cart > button').html('<i class="fa fa-shopping-cart"></i><span id="cart-total"> ' + json['total'] + '</span>');
 				}, 100);
 
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
@@ -218,7 +218,7 @@ var cart = {
 			success: function(json) {
 				// Need to set timeout otherwise it wont update the total
 				setTimeout(function () {
-					$('#cart > button').html('<span id="cart-total"><i class="fa fa-shopping-cart"></i> ' + json['total'] + '</span>');
+					$('#cart > button').html('<i class="fa fa-shopping-cart"></i><span id="cart-total"> ' + json['total'] + '</span>');
 				}, 100);
 
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {
@@ -253,7 +253,7 @@ var voucher = {
 			success: function(json) {
 				// Need to set timeout otherwise it wont update the total
 				setTimeout(function () {
-					$('#cart > button').html('<span id="cart-total"><i class="fa fa-shopping-cart"></i> ' + json['total'] + '</span>');
+					$('#cart > button').html('<i class="fa fa-shopping-cart"></i><span id="cart-total"> ' + json['total'] + '</span>');
 				}, 100);
 
 				if (getURLVar('route') == 'checkout/cart' || getURLVar('route') == 'checkout/checkout') {


### PR DESCRIPTION
Ao adicionar, remover ou editar um item do carrinho as funções nas linhas 164,192, 221, 256 estavam alterando a árvore de elementos HTML até a página ser recarregada, quando deveriam apenas alterar a quantidade de itens no carrinho, contido tag com Id “#cart-total”.

Inicialmente a árvore de elementos HTML, no elemento de Id “#cart”, (além dos elementos antecessores) possui uma tag “i” seguida de um “span”. Após chamar as funções precitadas, a árvore se torna uma tag “span” com uma tag “i” como sua FILHA. Ao recarregar a página, o fluxo de elementos volta ao inicial.
No tema “default” não é possível identificar essa alteração visualmente, mas em atualizações futuras pode ser um problema, por gerar uma alteração temporária no HTML, podendo impedir a aplicação de alguma regra CSS até o recarregamento da página.

A atualização corrige essa alteração na árvore de elementos HTML.